### PR TITLE
Support Chrome 115+

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -15,11 +17,11 @@
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
     <php>
         <const name="DUSK_UPDATER_TEST" value="true"/>
     </php>

--- a/src/DetectsChromeVersion.php
+++ b/src/DetectsChromeVersion.php
@@ -11,17 +11,28 @@ trait DetectsChromeVersion
      *
      * @var array
      */
-    protected $chromeCommands = [
+    protected static $platforms = [
         'linux' => [
-            '/usr/bin/google-chrome --version',
-            '/usr/bin/chromium-browser --version',
-            '/usr/bin/google-chrome-stable --version',
+            'slug' => 'linux64',
+            'commands' => [
+                '/usr/bin/google-chrome --version',
+                '/usr/bin/chromium-browser --version',
+                '/usr/bin/chromium --version',
+                '/usr/bin/google-chrome-stable --version',
+            ],
         ],
         'mac' => [
-            '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version',
+            'slug' => 'mac-x64',
+            'commands' => [
+                '/Applications/Google\ Chrome\ for\ Testing.app/Contents/MacOS/Google\ Chrome\ for\ Testing --version',
+                '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version',
+            ],
         ],
         'win' => [
-            'reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version',
+            'slug' => 'win32',
+            'commands' => [
+                'reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version',
+            ],
         ],
     ];
 
@@ -44,7 +55,7 @@ trait DetectsChromeVersion
 
             $commands = [$path.' --version'];
         } else {
-            $commands = $this->chromeCommands[$os];
+            $commands = static::$platforms[$os]['commands'];
         }
 
         foreach ($commands as $command) {
@@ -68,5 +79,33 @@ trait DetectsChromeVersion
         $this->error('Chrome version could not be detected. Please submit an issue: https://github.com/staudenmeir/dusk-updater');
 
         return false;
+    }
+
+    /**
+     * Resolve the ChromeDriver slug for the given operating system.
+     *
+     * @param string $operatingSystem
+     * @param string|null $version
+     * @return string
+     */
+    public static function chromeDriverSlug($operatingSystem, $version = null)
+    {
+        $slug = static::$platforms[$operatingSystem]['slug'] ?? null;
+
+        if (!is_null($version) && version_compare($version, '115.0', '<') && $slug === 'mac-x64') {
+            return 'mac64';
+        }
+
+        return $slug;
+    }
+
+    /**
+     * Get all supported operating systems.
+     *
+     * @return array
+     */
+    public static function all()
+    {
+        return array_keys(static::$platforms);
     }
 }

--- a/src/UpdateCommand.php
+++ b/src/UpdateCommand.php
@@ -251,6 +251,10 @@ class UpdateCommand extends Command
                 continue;
             }
 
+            if (version_compare($version, '115.0', '<') && $os === 'mac-arm') {
+                continue;
+            }
+
             $archive = $this->download($version, $os);
 
             $binary = $this->extract($version, $archive);
@@ -325,17 +329,5 @@ class UpdateCommand extends Command
         rename($this->directory.$binary, $this->directory.$newName);
 
         chmod($this->directory.$newName, 0755);
-    }
-
-    /**
-     * Detect the current operating system.
-     *
-     * @return string
-     */
-    protected function os()
-    {
-        return PHP_OS === 'WINNT' || Str::contains(php_uname(), 'Microsoft')
-            ? 'win'
-            : (PHP_OS === 'Darwin' ? 'mac' : 'linux');
     }
 }


### PR DESCRIPTION
This PR is closely modelled on the 2 Dusk PRs mentioned in #18 with a few differences mainly because the codebases aren't quite the same.

### Differences

- In this PR I changed to use cURL to download the archive (whereas Dusk uses the new HTTP Client / Guzzle)
  - `file_get_contents()` was causing an `HTTP/1.1 426 Upgrade Required` error
- Continued using the `DetectsChromeVersion` trait whereas Dusk has an `OperatingSystem` class
- Chosen not to add the new platform `OperatingSystem` tests
- Chosen not to throw exceptions and continue using `$this->error()`

### Side Note

- Your test suite doesn't run on a Windows machine - I don't know if you want another PR to fix that.